### PR TITLE
Redo API routing to be more idiomatic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ ShareY can be used as a ShareX custom upload server.
 
 - `GET /` returns a view of the main page.
 - `GET /{file_name}` returns a file if it exists.
-- `GET /api/upload/details/{file_name}` returns as a `JSON` details of the specified file. Requires `user` authorization.
-- `DELETE /api/upload/delete/{file_name}` deletes the specified file. Requires `user` authorization. Only the author can delete its upload.
+- `GET /api/upload/{file_name}` returns as a `JSON` details of the specified file. Requires `user` authorization.
+- `DELETE /api/upload/{file_name}` deletes the specified file. Requires `user` authorization. Only the author can delete its upload.
 - `POST /api/upload` uploads the given file in the body of the request. Requires `user` authorization. Redirects to `GET /{file_name}`.
-- `PATCH /api/user/unblock/{guid}` unblocks a user by it's guid. Requires `admin` authorization.
-- `PATCH /api/user/block/{guid}` blocks a user by it's guid. Requires `admin` authorization. `Admin` accounts cannot be blocked.
-- `DELETE /api/user/delete` deletes the authenticated account. Requires `user` authorization.
-- `PATCH /api/user/token/reset` resets the current user's token and returns the new generated one. Requires `user` authorization.
-- `DELETE /api/user/token/revoke` revokes the token of the current's user. Requires `user` authorization.
+- `PATCH /api/user/{guid}/block?block=false` unblocks a user by it's guid. Requires `admin` authorization.
+- `PATCH /api/user/{guid}/block?block=true` blocks a user by it's guid. Requires `admin` authorization. `Admin` accounts cannot be blocked.
+- `DELETE /api/user` deletes the authenticated account. Requires `user` authorization.
+- `DELETE /api/user/token?reset=true` resets the current user's token and returns the new generated one. Requires `user` authorization.
+- `DELETE /api/user/token` revokes the token of the current's user. Requires `user` authorization.
 - `PATCH /api/routes/{routeName}?state={boolean}` enables or disables a configurable route. Requires `admin` authorization. Unknown `routeName` returns every available routes.
-- `POST /api/user/create` creates a new user with the given `email` in a json body. Requires no authorization. (see exemple below)
+- `POST /api/user` creates a new user with the given `email` in a json body. Requires no authorization. (see exemple below)
 ```json
 {
   "Email": "your.email@exemple.com"

--- a/src/ShareY/Controllers/API/UploadController.cs
+++ b/src/ShareY/Controllers/API/UploadController.cs
@@ -25,7 +25,7 @@ namespace ShareY.Controllers
             _filesConfiguration = filesConfiguration.GetConfiguration();
         }
 
-        [HttpGet, Route("details/{name}")]
+        [HttpGet, Route("{name}")]
         public IActionResult DetailsUpload(string name)
         {
             var file = _dbContext.Uploads.FirstOrDefault(x => x.FileName == name);
@@ -56,7 +56,7 @@ namespace ShareY.Controllers
                 });
         }
 
-        [HttpDelete, Route("delete/{name}")]
+        [HttpDelete, Route("{name}")]
         public async Task<IActionResult> DeleteUpload(string name)
         {
             var file = _dbContext.Uploads.FirstOrDefault(x => x.FileName == name);
@@ -96,7 +96,7 @@ namespace ShareY.Controllers
             return Ok("File has been successfully removed.");
         }
 
-        [HttpPost, DisableRequestSizeLimit]
+        [HttpPost, Route(""), DisableRequestSizeLimit]
         public async Task<IActionResult> PostUpload()
         {
             foreach (var file in Request.Form.Files)


### PR DESCRIPTION
This PR redoes routing to be more idiomatic, as well as combines some routes with similar functionality, such that they are distinguished via GET param switch. The summary of changes is as follows:

* `GET /api/upload/details/{name}` -> `GET /api/upload/{name}`
* `DELETE /api/upload/delete/{name}` -> `DELETE /api/upload/{name}`
* `PATCH /api/user/token/reset` -> `DELETE /api/user/token?reset=true`
* `DELETE /api/user/token/revoke` -> `DELETE /api/user/token` or `DELETE /api/user/token?reset=false`
* `DELETE /api/user/delete` -> `DELETE /api/user`
* `POST /api/user/create` -> `POST /api/user`
* `PATCH /api/user/unblock/{guid}` -> `PATCH /api/user/{guid}/block?block=false`
* `PATCH /api/user/block/{guid}` -> `PATCH /api/user/{guid}/block?block=true`