### PR TITLE
Migrated authorization to policy-based authorization

### DIFF
--- a/src/ShareY/Attributes/RequiresAdminAuthentication.cs
+++ b/src/ShareY/Attributes/RequiresAdminAuthentication.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace ShareY.Attributes
-{
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
-    public class RequiresAdminAuthentication : Attribute
-    {
-    }
-}

--- a/src/ShareY/Attributes/RequiresAuthentication.cs
+++ b/src/ShareY/Attributes/RequiresAuthentication.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace ShareY.Attributes
-{
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
-    public class RequiresAuthentication : Attribute
-    {
-    }
-}

--- a/src/ShareY/Authentications/Policies.cs
+++ b/src/ShareY/Authentications/Policies.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using ShareY.Database.Enums;
+
+namespace ShareY.Authentications
+{
+    public sealed class AdminRequirement : IAuthorizationRequirement 
+    {
+        public const string PolicyName = "RequireAdminPrivileges";
+    }
+
+    public sealed class AdminRequirementHandler : AuthorizationHandler<AdminRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, AdminRequirement requirement)
+        {
+            if (context.User.Identity.IsAuthenticated && context.User.IsInRole(TokenType.Admin.ToString()))
+                context.Succeed(requirement);
+            else
+                context.Fail(); // hard fail
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class UserRequirement : IAuthorizationRequirement
+    {
+        public const string PolicyName = "RequireUserPrivileges";
+    }
+
+    public sealed class UserRequirementHandler : AuthorizationHandler<UserRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, UserRequirement requirement)
+        {
+            if (context.User.Identity.IsAuthenticated && context.User.IsInRole(TokenType.User.ToString()))
+                context.Succeed(requirement);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/ShareY/Controllers/API/UploadController.cs
+++ b/src/ShareY/Controllers/API/UploadController.cs
@@ -133,7 +133,7 @@ namespace ShareY.Controllers
 
                 var upload = new Upload
                 {
-                    AuthorGuid = Guid.Parse(HttpContext.User.Claims.FirstOrDefault(x => x.Type == ClaimTypes.NameIdentifier)?.Value),
+                    AuthorGuid = Guid.Parse(User.Claims.FirstOrDefault(x => x.Type == ClaimTypes.NameIdentifier)?.Value),
                     CreatedAt = DateTime.Now,
                     ViewCount = 0,
                     Removed = false,

--- a/src/ShareY/Controllers/API/UploadController.cs
+++ b/src/ShareY/Controllers/API/UploadController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -132,7 +133,7 @@ namespace ShareY.Controllers
 
                 var upload = new Upload
                 {
-                    AuthorGuid = Guid.Parse(HttpContext.User.Identity.Name),
+                    AuthorGuid = Guid.Parse(HttpContext.User.Claims.FirstOrDefault(x => x.Type == ClaimTypes.NameIdentifier)?.Value),
                     CreatedAt = DateTime.Now,
                     ViewCount = 0,
                     Removed = false,

--- a/src/ShareY/Controllers/API/UserController.cs
+++ b/src/ShareY/Controllers/API/UserController.cs
@@ -68,7 +68,7 @@ namespace ShareY.Controllers
                 return BadRequest("Invalid token supplied.");
             }
 
-            var user = _dbContext.Users.FirstOrDefault(x => x.Guid == userGuid);
+            var user = _dbContext.Users.Include(x => x.Token).FirstOrDefault(x => x.Guid == userGuid);
             if (user is null)
             {
                 return BadRequest("Unknown token supplied.");

--- a/src/ShareY/Controllers/AdminController.cs
+++ b/src/ShareY/Controllers/AdminController.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using ShareY.Attributes;
+using ShareY.Authentications;
 using ShareY.Database;
 using ShareY.Models;
 
 namespace ShareY.Controllers
 {
-    [Route("admin"), RequiresAdminAuthentication]
+    [Route("admin"), Authorize(Policy = AdminRequirement.PolicyName)]
     public class AdminController : ShareYController
     {
         public AdminController(ShareYContext dbContext) : base(dbContext)

--- a/src/ShareY/Controllers/ShareYController.cs
+++ b/src/ShareY/Controllers/ShareYController.cs
@@ -1,15 +1,6 @@
 ﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Controllers;
-using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.EntityFrameworkCore;
-using ShareY.Attributes;
 using ShareY.Database;
-using ShareY.Database.Enums;
-using ShareY.Database.Models;
-using ShareY.Extensions;
 
 namespace ShareY.Controllers
 {
@@ -17,49 +8,9 @@ namespace ShareY.Controllers
     {
         protected readonly ShareYContext _dbContext;
 
-        public Guid? UserToken { get; private set; }
-
-        public User DbUser { get; private set; }
-
         public ShareYController(ShareYContext dbContext)
         {
             _dbContext = dbContext;
-        }
-
-        public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
-        {
-            await base.OnActionExecutionAsync(context, next);
-
-            UserToken = context.HttpContext.Session.Get<Guid?>("userToken");
-
-            DbUser = await _dbContext.Users.Include(x => x.Token).FirstOrDefaultAsync(x => x.Token.Guid == UserToken);
-
-            ViewData["IsAuthenticated"] = DbUser != null && !DbUser.Disabled && !DbUser.Token.Revoked;
-            ViewData["IsAdmin"] = DbUser != null && !DbUser.Disabled && !DbUser.Token.Revoked && DbUser.Token.TokenType == TokenType.Admin;
-
-            if (DbUser != null)
-            {
-                ViewData["UserToken"] = DbUser.Token.Guid.ToString();
-            }
-
-            if (context.ActionDescriptor is ControllerActionDescriptor actionDescriptor)
-            {
-                var controller = actionDescriptor.ControllerTypeInfo;
-                var method = actionDescriptor.MethodInfo;
-
-                var attributes = controller.CustomAttributes.ToList();
-                attributes.AddRange(method.CustomAttributes);
-
-                if (attributes.Any(x => x.AttributeType == typeof(RequiresAdminAuthentication)) && !(bool)ViewData["IsAdmin"])
-                {
-                    throw new Exception("Admin authentication required.");
-                }
-
-                if (attributes.Any(x => x.AttributeType == typeof(RequiresAuthentication)) && !(bool)ViewData["IsAuthenticated"])
-                {
-                    throw new Exception("Authentication required.");
-                }
-            }
         }
     }
 }

--- a/src/ShareY/ShareY.csproj
+++ b/src/ShareY/ShareY.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <Content Update="sharey.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/src/ShareY/Views/Admin/Uploads.cshtml
+++ b/src/ShareY/Views/Admin/Uploads.cshtml
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css" />
 <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
 
-<input hidden id="token" value="@ViewData["UserToken"]" />
+<input hidden id="token" value="@User.Claims.FirstOrDefault(x => x.Type == TokenAuthenticationHandler.ClaimToken)?.Value" />
 <div class="container">
     <h1>Upload list</h1>
     <table id="uploadTable" class="table table-striped table-bordered  table-responsive-md">

--- a/src/ShareY/Views/Auth/Login.cshtml
+++ b/src/ShareY/Views/Auth/Login.cshtml
@@ -5,9 +5,9 @@
 
 <form method="post">
     @{
-        if ((bool)ViewData["IsAuthenticated"])
+        if (User.Identity.IsAuthenticated)
         {
-            <p class="alert alert-danger">You are already logged in as '@ViewData["UserToken"]'.</p>
+            <p class="alert alert-danger">You are already logged in as '@User.Identity.Name'.</p>
         }
     }
 

--- a/src/ShareY/Views/Auth/Signup.cshtml
+++ b/src/ShareY/Views/Auth/Signup.cshtml
@@ -7,9 +7,9 @@
 }
 
 @{
-    if ((bool)ViewData["IsAuthenticated"])
+    if (User.Identity.IsAuthenticated)
     {
-        <p class="alert alert-warning">You are already logged in as '@ViewData["UserToken"]'</p>
+        <p class="alert alert-warning">You are already logged in as '@User.Identity.Name'</p>
     }
     else if (token.HasValue)
     {
@@ -32,6 +32,6 @@
     }
     else
     {
-        <p class="alert alert-warning">Creating an account is not enabled.</p>
+        <p class="alert alert-warning">Account creation is currently disabled.</p>
     }
 }

--- a/src/ShareY/Views/Index/Index.cshtml
+++ b/src/ShareY/Views/Index/Index.cshtml
@@ -2,14 +2,13 @@
     ViewData["Title"] = "Home Page";
 }
 
-@using ShareY.Interfaces
 @inject IFilesConfigurationProvider files
 @{
     var filesConfig = files.GetConfiguration();
 }
 
 <div class="container">
-    @if ((bool)ViewData["IsAuthenticated"])
+    @if (User.Identity.IsAuthenticated)
     {
         <div class="form-group">
             <div>
@@ -20,7 +19,7 @@
         </div>
         <div class="form-group">
             <div>
-                <input type="submit" value="Upload" onclick="uploadFile('@ViewData["UserToken"]')">
+                <input type="submit" value="Upload" onclick="uploadFile('@User.Claims.FirstOrDefault(x => x.Type == TokenAuthenticationHandler.ClaimToken)?.Value')">
             </div>
         </div>
 
@@ -35,7 +34,7 @@
     }
 </div>
 
-@if ((bool)ViewData["IsAuthenticated"])
+@if (User.Identity.IsAuthenticated)
 {
     <script type="text/javascript">
         function uploadFile(token) {

--- a/src/ShareY/Views/Shared/_Layout.cshtml
+++ b/src/ShareY/Views/Shared/_Layout.cshtml
@@ -1,5 +1,4 @@
-﻿@using ShareY.Interfaces
-@inject IRoutesConfigurationProvider routes
+﻿@inject IRoutesConfigurationProvider routes
 @{
     var routesConfig = routes.GetConfiguration();
 }
@@ -48,21 +47,21 @@
                         </li>
                     </ul>
                     <ul class="nav navbar-nav">
-                        @if (routesConfig.UserRegisterRoute && !(bool)ViewData["IsAuthenticated"])
+                        @if (routesConfig.UserRegisterRoute && !User.Identity.IsAuthenticated)
                         {
                             <li class="nav-item">
                                 <a class="nav-link text-dark" asp-area="" asp-controller="Auth" asp-action="Signup">Signin</a>
                             </li>
                         }
 
-                        @if ((bool)ViewData["IsAdmin"])
+                        @if (User.IsInRole(TokenType.Admin.ToString()))
                         {
                             <li class="nav-item">
                                 <a class="nav-link text-dark" asp-area="" asp-controller="Admin" asp-action="Index">Admin Area</a>
                             </li>
                         }
 
-                        @if (!(bool)ViewData["IsAuthenticated"])
+                        @if (!User.Identity.IsAuthenticated)
                         {
                             <li class="nav-item">
                                 <a class="nav-link text-dark" asp-area="" asp-controller="Auth" asp-action="Login">Login</a>

--- a/src/ShareY/Views/_ViewImports.cshtml
+++ b/src/ShareY/Views/_ViewImports.cshtml
@@ -1,4 +1,7 @@
 ﻿@using ShareY
+@using ShareY.Authentications
+@using ShareY.Interfaces
 @using ShareY.Models
-@using ShareY.Database.Models;
+@using ShareY.Database.Models
+@using ShareY.Database.Enums
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
Yes, I realize the commit message is incorrect.

This PR migrates the existing hacky implementation of authorization to ASP.NET Core's policy-based authorization mechanisms. This not only simplifies the codebase, but also future-proofs it somewhat.

Currently unresolved issues:
- ~~Blocking a user has no effect. I am still awaiting input on what it's supposed to be doing.~~ Resolved